### PR TITLE
replace deprecated GenEvent

### DIFF
--- a/lib/lifx/handler.ex
+++ b/lib/lifx/handler.ex
@@ -1,14 +1,14 @@
 defmodule Lifx.Handler do
-    use GenEvent
+    use GenServer
     require Logger
     alias Lifx.Device.State, as: Device
 
-    def init do
-        {:ok, []}
+    def init(args) do
+        {:ok, args}
     end
 
-    def handle_event(%Device{} = device, parent) do
+    def handle_cast(%Device{} = device, parent) do
         send(parent, device)
-        {:ok, parent}
+        {:noreply, parent}
     end
 end


### PR DESCRIPTION
Replaced the deprecated GenEvent with the Supervisor, GenServer structure mentioned [in the docs](https://hexdocs.pm/elixir/GenEvent.html#module-supervisor-and-genservers) using [this blog post](https://web.archive.org/web/20170818051039/http://blog.plataformatec.com.br:80/2016/11/replacing-genevent-by-a-supervisor-genserver/) by José Valim