### PR TITLE
fix devices not persisted in client

### DIFF
--- a/lib/lifx/client.ex
+++ b/lib/lifx/client.ex
@@ -44,7 +44,7 @@ defmodule Lifx.Client do
     end
 
     def add_handler(handler) do
-        GenServer.cast(__MODULE__, [{:handler, handler, self()}])
+        GenServer.cast(__MODULE__, {:handler, handler, self()})
     end
 
     def start do
@@ -96,7 +96,7 @@ defmodule Lifx.Client do
         {:reply, :ok, state}
     end
 
-    def handle_cast([{:handler, handler, pid}], state) do
+    def handle_cast({:handler, handler, pid}, state) do
         GenEvent.add_mon_handler(state.events, handler, pid)
         {:noreply, %{state | :handlers => [{handler, pid} | state.handlers]}}
     end

--- a/lib/lifx/client.ex
+++ b/lib/lifx/client.ex
@@ -44,7 +44,7 @@ defmodule Lifx.Client do
     end
 
     def add_handler(handler) do
-        GenServer.call(__MODULE__, {:handler, handler})
+        GenServer.cast(__MODULE__, [{:handler, handler, self()}])
     end
 
     def start do
@@ -66,6 +66,7 @@ defmodule Lifx.Client do
           {:reuseaddr, true}
       ]
       {:ok, udp} = :gen_udp.open(0 , udp_options)
+      add_handler(Lifx.Handler)
       Process.send_after(self(), :discover, 0)
       {:reply, :ok, %State{state | udp: udp}}
     end
@@ -95,9 +96,9 @@ defmodule Lifx.Client do
         {:reply, :ok, state}
     end
 
-    def handle_call({:handler, handler}, {pid, _} = from, state) do
+    def handle_cast([{:handler, handler, pid}], state) do
         GenEvent.add_mon_handler(state.events, handler, pid)
-        {:reply, :ok, %{state | :handlers => [{handler, pid} | state.handlers]}}
+        {:noreply, %{state | :handlers => [{handler, pid} | state.handlers]}}
     end
 
     def handle_call(:devices, _from, state) do

--- a/lib/lifx/client.ex
+++ b/lib/lifx/client.ex
@@ -143,6 +143,7 @@ defmodule Lifx.Client do
             :host => ip,
             :port => packet.payload.port
         }
+        Process.send(__MODULE__, d, [])
         case Process.whereis(d.id) do
             nil -> Lifx.DeviceSupervisor.start_device(d)
             _ -> true

--- a/lib/lifx/handler.ex
+++ b/lib/lifx/handler.ex
@@ -1,6 +1,5 @@
 defmodule Lifx.Handler do
     use GenEvent
-    require Logger
     alias Lifx.Device.State, as: Device
 
     def init do

--- a/test/lifx_client_test.exs
+++ b/test/lifx_client_test.exs
@@ -50,9 +50,22 @@ defmodule LifxTest do
         assert Protocol.parse_packet(bin) == @discovery_packet
     end
 
+    defmodule Handler do
+        use GenEvent
+
+        def init do
+            {:ok, []}
+        end
+
+        def handle_event(%Device{} = device, parent) do
+            send(parent, device)
+            {:ok, parent}
+        end
+    end
+
     test "Client event handler" do
         Lifx.Client.start
-        Lifx.Client.add_handler(Lifx.Handler)
+        Lifx.Client.add_handler(LifxTest.Handler)
         assert_receive(%Device{}, 10000)
     end
 end


### PR DESCRIPTION
`Lifx.Client.devices` always returned an empty list, because the client didn't inform itself about new devices